### PR TITLE
Pin the futures-preview version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.4.12"
-futures-preview = "0.3.0-alpha.15"
+futures-preview = "=0.3.0-alpha.16"


### PR DESCRIPTION
Until a better fix, pinning the futures-preview version should help with the compile errors

Fixes https://github.com/matthunz/futures-codec/issues/2