### PR TITLE
Allow releasing the I/O and codec

### DIFF
--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -41,6 +41,12 @@ where
             inner: framed_read_2(Fuse(inner, decoder)),
         }
     }
+
+    /// Release the I/O and Decoder
+    pub fn release(self: Self) -> (T, D) {
+        let fuse = self.inner.release();
+        (fuse.0, fuse.1)
+    }
 }
 
 impl<T, D> Stream for FramedRead<T, D>
@@ -119,5 +125,11 @@ where
     }
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::SinkError>> {
         Pin::new(&mut self.inner).poll_close(cx)
+    }
+}
+
+impl<T> FramedRead2<T>  {
+    pub fn release(self: Self) -> T {
+        self.inner
     }
 }

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -41,6 +41,12 @@ where
             inner: framed_write_2(Fuse(inner, encoder)),
         }
     }
+
+    /// Release the I/O and Encoder
+    pub fn release(self: Self) -> (T, E) {
+        let fuse = self.inner.release();
+        (fuse.0, fuse.1)
+    }
 }
 
 impl<T, E> Sink<E::Item> for FramedWrite<T, E>
@@ -108,5 +114,11 @@ where
     }
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::SinkError>> {
         Pin::new(&mut self.inner).poll_close(cx).map_err(Into::into)
+    }
+}
+
+impl<T> FramedWrite2<T> {
+    pub fn release(self: Self) -> T {
+        self.inner
     }
 }


### PR DESCRIPTION
Add a release() method to Framed, FramedRead, and FramedWrite.
This method consumes the Framed and returns the underlying I/O
object and Codec as a tuple.