### PR TITLE
futures_api is stable since 1.36

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(futures_api)]
 //! Utilities for encoding and decoding frames using `async/await`.
 //!
 //! Contains adapters to go from streams of bytes, [`AsyncRead`](futures::io::AsyncRead)


### PR DESCRIPTION
This removes a warning