### PR TITLE
Fix a bug in FramedWrite2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,7 @@ edition = "2018"
 [dependencies]
 bytes = "0.4.12"
 futures-preview = "0.3.0-alpha.17"
+
+[dev-dependencies]
+romio = "0.3.0-alpha.9"
+async_runtime = { version = "=0.1.7", package = "naja_async_runtime" }

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -20,10 +20,10 @@ use std::task::{Context, Poll};
 /// executor::block_on(async move {
 ///     let mut buf = Vec::new();
 ///     let mut framed = FramedWrite::new(&mut buf, BytesCodec {});
-///     
+///
 ///     let msg = Bytes::from("Hello World!");
 ///     framed.send(msg.clone()).await.unwrap();
-///     
+///
 ///     assert_eq!(&buf[..], &msg[..]);
 /// })
 /// ```
@@ -109,7 +109,8 @@ where
     }
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         let this = &mut *self;
-        ready!(Pin::new(&mut this.inner).poll_write(cx, &this.buffer))?;
+        let n = ready!(Pin::new(&mut this.inner).poll_write(cx, &this.buffer))?;
+        this.buffer.split_to(n+1);
         Pin::new(&mut self.inner).poll_flush(cx).map_err(Into::into)
     }
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {

--- a/tests/romio.rs
+++ b/tests/romio.rs
@@ -1,0 +1,64 @@
+#![feature(async_await)]
+
+use
+{
+	romio::tcp    :: { TcpListener, TcpStream } ,
+	futures       :: { prelude::*             } ,
+	async_runtime :: { rt, RtConfig           } ,
+	futures_codec :: { Framed, LinesCodec     } ,
+};
+
+
+#[test]
+//
+fn receive_twice()
+{
+	rt::init( RtConfig::Local ).expect( "rt::init" );
+
+	let server = async
+	{
+		let     socket_addr  = "127.0.0.1:3323".parse().expect( "parse address" );
+		let mut listener     = TcpListener::bind(&socket_addr).expect( "bind tcp" );
+		let mut incoming     = listener.incoming();
+		let stream           = incoming.next().await.expect( "get stream" ).expect( "get stream" );
+
+		let mut framed = Framed::new( stream, LinesCodec {} );
+
+		framed.send( "A line\n"       .to_string() ).await.expect( "Send a line" );
+		framed.send( "A second line\n".to_string() ).await.expect( "Send a line" );
+	};
+
+	let client = async
+	{
+		let     socket_addr  = "127.0.0.1:3323".parse().expect( "parse address" );
+		let stream = TcpStream::connect(&socket_addr).await.expect( "connect tcp" );
+
+		let mut framed = Framed::new( stream, LinesCodec {} );
+
+
+		let res = framed.next().await.expect( "Receive some" ).expect( "Receive a line" );
+		dbg!( &res );
+		assert_eq!( "A line\n".to_string(), res );
+
+
+		let res = framed.next().await.expect( "Receive some" ).expect( "Receive a second line" );
+		dbg!( &res );
+
+		assert_eq!( "A line\n".to_string(), res );
+
+
+		let res = framed.next().await.expect( "Receive some" ).expect( "Receive a second line" );
+		dbg!( &res );
+		assert_eq!( "A second line\n".to_string(), res );
+
+
+		let res = framed.next().await;
+		dbg!( &res );
+		assert!( res.is_none() );
+	};
+
+	rt::spawn( server ).expect( "spawn task" );
+	rt::spawn( client ).expect( "spawn task" );
+
+	rt::run();
+}

--- a/tests/romio.rs
+++ b/tests/romio.rs
@@ -24,8 +24,9 @@ fn receive_twice()
 
 		let mut framed = Framed::new( stream, LinesCodec {} );
 
-		framed.send( "A line\n"       .to_string() ).await.expect( "Send a line" );
-		framed.send( "A second line\n".to_string() ).await.expect( "Send a line" );
+		framed.send( "A line\n"       .to_string() ).await.expect( "Send a line"        );
+		framed.send( "A second line\n".to_string() ).await.expect( "Send a second line" );
+		framed.send( "A third line\n" .to_string() ).await.expect( "Send a third line"  );
 	};
 
 	let client = async
@@ -50,6 +51,22 @@ fn receive_twice()
 		let res = framed.next().await.expect( "Receive some" ).expect( "Receive a second line" );
 		dbg!( &res );
 		assert_eq!( "A second line\n".to_string(), res );
+
+
+		let res = framed.next().await.expect( "Receive some" ).expect( "Receive a second line" );
+		dbg!( &res );
+
+		assert_eq!( "A line\n".to_string(), res );
+
+
+		let res = framed.next().await.expect( "Receive some" ).expect( "Receive a second line" );
+		dbg!( &res );
+		assert_eq!( "A second line\n".to_string(), res );
+
+
+		let res = framed.next().await.expect( "Receive some" ).expect( "Receive a second line" );
+		dbg!( &res );
+		assert_eq!( "A third line\n".to_string(), res );
 
 
 		let res = framed.next().await;

--- a/tests/romio.rs
+++ b/tests/romio.rs
@@ -9,6 +9,10 @@ use
 };
 
 
+// This test caught a bug in FramedWrite2::poll_flush. The written out bytes did not get removed
+// from the buffer. This test assures correct integration of the LinesCodec, both encoding and
+// decoding.
+//
 #[test]
 //
 fn receive_twice()
@@ -39,23 +43,6 @@ fn receive_twice()
 
 		let res = framed.next().await.expect( "Receive some" ).expect( "Receive a line" );
 		dbg!( &res );
-		assert_eq!( "A line\n".to_string(), res );
-
-
-		let res = framed.next().await.expect( "Receive some" ).expect( "Receive a second line" );
-		dbg!( &res );
-
-		assert_eq!( "A line\n".to_string(), res );
-
-
-		let res = framed.next().await.expect( "Receive some" ).expect( "Receive a second line" );
-		dbg!( &res );
-		assert_eq!( "A second line\n".to_string(), res );
-
-
-		let res = framed.next().await.expect( "Receive some" ).expect( "Receive a second line" );
-		dbg!( &res );
-
 		assert_eq!( "A line\n".to_string(), res );
 
 


### PR DESCRIPTION
`FramedWrite2::flush` did not remove bytes that were written out from the internal buffer, writing all data for every new item. 

This contains an integration test demonstrating the problem, and the fix. I didn't manage to get `send` working with `Cursor`, so I made a more real-life like test with romio TCP. 
You might want to transform this into an example because it might be useful for others to see it work with romio.