### PR TITLE
Fix incorrect output from FramedWrite

### DIFF
--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -75,8 +75,6 @@ pub struct FramedWrite2<T> {
     buffer: BytesMut,
 }
 
-const SEND_HIGH_WATER_MARK: usize = 8 * 1024;
-
 pub fn framed_write_2<T>(inner: T) -> FramedWrite2<T> {
     FramedWrite2 {
         inner,
@@ -102,11 +100,7 @@ where
 {
     type Error = T::Error;
 
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        while self.buffer.len() > SEND_HIGH_WATER_MARK {
-            ready!(Pin::new(&mut *self).poll_flush(cx))?;
-        }
-
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
     fn start_send(mut self: Pin<&mut Self>, item: T::Item) -> Result<(), Self::Error> {

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -75,6 +75,8 @@ pub struct FramedWrite2<T> {
     buffer: BytesMut,
 }
 
+const SEND_HIGH_WATER_MARK: usize = 8 * 1024;
+
 pub fn framed_write_2<T>(inner: T) -> FramedWrite2<T> {
     FramedWrite2 {
         inner,
@@ -100,7 +102,11 @@ where
 {
     type Error = T::Error;
 
-    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        while self.buffer.len() > SEND_HIGH_WATER_MARK {
+            ready!(Pin::new(&mut *self).poll_flush(cx))?;
+        }
+
         Poll::Ready(Ok(()))
     }
     fn start_send(mut self: Pin<&mut Self>, item: T::Item) -> Result<(), Self::Error> {

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -110,8 +110,6 @@ where
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         let this = &mut *self;
 
-        ready!(Pin::new(&mut this.inner).poll_flush(cx).map_err(Into::into))?;
-
         while !this.buffer.is_empty() {
             let num_write = ready!(Pin::new(&mut this.inner).poll_write(cx, &this.buffer))?;
 
@@ -122,9 +120,9 @@ where
             }
 
             let _ = this.buffer.split_to(num_write);
-            ready!(Pin::new(&mut this.inner).poll_flush(cx).map_err(Into::into))?;
         }
-        Poll::Ready(Ok(()))
+
+        Pin::new(&mut this.inner).poll_flush(cx).map_err(Into::into)
     }
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         ready!(self.as_mut().poll_flush(cx))?;

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -144,4 +144,15 @@ mod test {
         assert_eq!(&curs.get_ref()[0..12], b"Hello\nWorld\n");
         assert_eq!(curs.position(), 12);
     }
+
+    #[test]
+    fn line_write_to_eof() {
+        let curs = Cursor::new(vec![0u8; 16]);
+        let mut framer = FramedWrite::new(curs, LinesCodec {});
+        let _err = executor::block_on(framer.send("This will fill up the buffer\n".to_owned()))
+            .unwrap_err();
+        let (curs, _) = framer.release();
+        assert_eq!(curs.position(), 16);
+        assert_eq!(&curs.get_ref()[0..16], b"This will fill u");
+    }
 }

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -124,7 +124,9 @@ where
         Poll::Ready(Ok(()))
     }
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut self.inner).poll_close(cx).map_err(Into::into)
+        let this = &mut *self;
+        ready!(Pin::new(&mut this.inner).poll_flush(cx).map_err(Into::into))?;
+        Pin::new(&mut this.inner).poll_close(cx).map_err(Into::into)
     }
 }
 

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -109,6 +109,9 @@ where
     }
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
         let this = &mut *self;
+
+        ready!(Pin::new(&mut this.inner).poll_flush(cx).map_err(Into::into))?;
+
         while !this.buffer.is_empty() {
             let num_write = ready!(Pin::new(&mut this.inner).poll_write(cx, &this.buffer))?;
 
@@ -124,9 +127,8 @@ where
         Poll::Ready(Ok(()))
     }
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        let this = &mut *self;
-        ready!(Pin::new(&mut this.inner).poll_flush(cx).map_err(Into::into))?;
-        Pin::new(&mut this.inner).poll_close(cx).map_err(Into::into)
+        ready!(Pin::new(&mut *self).poll_flush(cx))?;
+        Pin::new(&mut (*self).inner).poll_close(cx).map_err(Into::into)
     }
 }
 

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -133,8 +133,8 @@ where
         Poll::Ready(Ok(()))
     }
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        ready!(Pin::new(&mut *self).poll_flush(cx))?;
-        Pin::new(&mut (*self).inner).poll_close(cx).map_err(Into::into)
+        ready!(self.as_mut().poll_flush(cx))?;
+        Pin::new(&mut self.inner).poll_close(cx).map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
The `FramedWrite` has a number of important issues which prevent it from working correctly. These issues are not covered by the existing doctests:

1. Multiple sends will emit old buffer content
2. End of file / EOF is not handled
3. `poll_close()` might not perform as the Trait specifies—needs discussion.
4. The Sink should exert backpressure on data producers to ensure that they do not run ahead of the I/O.

This patch set adds tests which demonstrate the issues and proposes fixes for them. Please review 39ea2ce68cbf closely, as I am not certain what behavior `poll_close()` should actually have. This patch may require further discussion.

It would be a worthwhile endeavor to add some similar tests to `FramedRead`.