### PR TITLE
Reserve before putting in a BytesMut

### DIFF
--- a/src/codec/bytes.rs
+++ b/src/codec/bytes.rs
@@ -29,6 +29,16 @@ use std::io::Error;
 /// ```
 pub struct BytesCodec {}
 
+impl Encoder for BytesCodec {
+    type Item = Bytes;
+    type Error = Error;
+
+    fn encode(&mut self, src: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        dst.extend_from_slice(&src);
+        Ok(())
+    }
+}
+
 impl Decoder for BytesCodec {
     type Item = Bytes;
     type Error = Error;
@@ -40,15 +50,5 @@ impl Decoder for BytesCodec {
         } else {
             Ok(None)
         }
-    }
-}
-
-impl Encoder for BytesCodec {
-    type Item = Bytes;
-    type Error = Error;
-
-    fn encode(&mut self, src: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        dst.extend_from_slice(&src);
-        Ok(())
     }
 }

--- a/src/codec/lines.rs
+++ b/src/codec/lines.rs
@@ -10,6 +10,7 @@ impl Encoder for LinesCodec {
     type Error = Error;
 
     fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        dst.reserve(item.len());
         dst.put(item);
         Ok(())
     }


### PR DESCRIPTION
According to [the documentation of BytesMut](https://docs.rs/bytes/0.4.12/bytes/struct.BytesMut.html#growth), the buffer doesn't grow implicitly, so we have to reserve before putting bytes into it. I have hit the bug where a panic tells me that "self.remaining_mut() >= self.remaining()" or something like that.

I have also reordered the `Encode` and `Decode` implementations for `BytesCodec`.

And just for your information, unit structs exists, you could have made `BytesCodec` and `LinesCodec` unit struct (i.e. `struct LinesCodec;`) and not _empty_ structs (i.e. `struct LinesCodec {}`). This would have made the code a little bit easier to use and to read. But now it is a breaking change, so, it's up to you 😁