### PR TITLE
Introduce the LengthCodec

### DIFF
--- a/src/codec/length.rs
+++ b/src/codec/length.rs
@@ -1,0 +1,79 @@
+use crate::{Decoder, Encoder};
+use bytes::{Bytes, BytesMut, BufMut, BigEndian, ByteOrder};
+use std::io::Error;
+
+const U64_LENGTH: usize = std::mem::size_of::<u64>();
+
+/// A simple `Codec` implementation sending your data by prefixing it by its length.
+///
+/// # Example
+///
+/// This codec will most likely be used wrapped in another codec like so.
+///
+/// ```rust
+/// use futures_codec::{Decoder, Encoder, LengthCodec};
+/// use bytes::{Bytes, BytesMut};
+/// use std::io::{Error, ErrorKind};
+///
+/// pub struct MyStringCodec(LengthCodec);
+///
+/// impl Encoder for MyStringCodec {
+///     type Item = String;
+///     type Error = Error;
+///
+///     fn encode(&mut self, src: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+///         let bytes = Bytes::from(src);
+///         self.0.encode(bytes, dst)
+///     }
+/// }
+///
+/// impl Decoder for MyStringCodec {
+///     type Item = String;
+///     type Error = Error;
+///
+///     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+///         match self.0.decode(src)? {
+///             Some(bytes) => {
+///                 match String::from_utf8(bytes.to_vec()) {
+///                     Ok(string) => Ok(Some(string)),
+///                     Err(e) => Err(Error::new(ErrorKind::InvalidData, e))
+///                 }
+///             },
+///             None => Ok(None),
+///         }
+///     }
+/// }
+/// ```
+pub struct LengthCodec;
+
+impl Encoder for LengthCodec {
+    type Item = Bytes;
+    type Error = Error;
+
+    fn encode(&mut self, src: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        dst.reserve(U64_LENGTH + src.len());
+        dst.put_u64_be(src.len() as u64);
+        dst.extend_from_slice(&src);
+        Ok(())
+    }
+}
+
+impl Decoder for LengthCodec {
+    type Item = Bytes;
+    type Error = Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if src.len() < U64_LENGTH {
+            return Ok(None)
+        }
+
+        let len = BigEndian::read_u64(&src[..U64_LENGTH]) as usize;
+
+        if src.len() - U64_LENGTH >= len {
+            src.advance(U64_LENGTH);
+            Ok(Some(src.split_to(len).freeze()))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,5 +1,8 @@
 mod bytes;
 pub use self::bytes::BytesCodec;
 
+mod length;
+pub use self::length::LengthCodec;
+
 mod lines;
 pub use self::lines::LinesCodec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! ```
 
 mod codec;
-pub use codec::{BytesCodec, LinesCodec};
+pub use codec::{BytesCodec, LinesCodec, LengthCodec};
 
 mod decoder;
 pub use decoder::Decoder;


### PR DESCRIPTION
Here is a really simple implementation of a length delimited codec.

This is a codec that you will most of the time wrap into your own codec, your wrapper codec will produce `Bytes` and will give them to the underlying `LengthCodec` that will do the job of delimiting them with their length.

Same thing when you decode, you ask for the `LengthCodec` to give you a block of bytes then interpret those with the wrapper codec.

I will have to rebase once you merged the #15 PR first, if you want to merge it, obviously :)

EDIT: rebased!