### PR TITLE
Receiving multiple messages at once can stall FramedRead

### DIFF
--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -83,6 +83,11 @@ where
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = &mut *self;
+
+        if let Some(item) = this.inner.decode(&mut this.buffer)? {
+            return Poll::Ready(Some(Ok(item)));
+        }
+
         let mut buf = [0u8; INITIAL_CAPACITY];
 
         loop {

--- a/tests/framed_read.rs
+++ b/tests/framed_read.rs
@@ -1,0 +1,38 @@
+use futures::executor;
+use futures::stream::StreamExt;
+use futures::task::Context;
+use futures::{AsyncRead, Poll};
+use futures_codec::{FramedRead, LinesCodec};
+use std::io;
+use std::pin::Pin;
+
+// Sends two lines at once, then nothing else forever
+struct MockBurstySender {
+    sent: bool,
+}
+impl AsyncRead for MockBurstySender {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        const MESSAGES: &'static [u8] = b"one\ntwo\n";
+        if !self.sent && buf.len() >= MESSAGES.len() {
+            self.sent = true;
+            buf[0..MESSAGES.len()].clone_from_slice(MESSAGES);
+            Poll::Ready(Ok(MESSAGES.len()))
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+#[test]
+fn line_read_multi() {
+    let io = MockBurstySender { sent: false };
+    let mut framed = FramedRead::new(io, LinesCodec {});
+    let one = executor::block_on(framed.next()).unwrap().unwrap();
+    assert_eq!(one, "one\n");
+    let two = executor::block_on(framed.next()).unwrap().unwrap();
+    assert_eq!(two, "two\n");
+}


### PR DESCRIPTION
The present `FramedRead` requires that a read from the I/O complete before a message can be framed. The OS may deliver any number of messages per read, including two or more. If multiple messages are received at once, *and* if further reads block `Pending`, then the `FramedRead` will stall `Pending` with messages remaining in the buffer. If further I/O is not possible—i.e., because there is no peer data left—then `FramedRead` will remain stalled indefinitely. The remaining data cannot be framed.

This bug may cause race-like or hang-like behavior in request-reply protocols.

This PR adds a test for this behavior and proposes a fix.