### PR TITLE
Use memchr for finding end of line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ categories = ["asynchronous", "network-programming"]
 [dependencies]
 bytes = "0.4.12"
 futures-preview = "0.3.0-alpha.17"
+memchr = "2.2.1"

--- a/benches/lines.rs
+++ b/benches/lines.rs
@@ -1,0 +1,64 @@
+#![feature(test)]
+
+extern crate test;
+
+use futures::{executor, TryStreamExt};
+use futures_codec::{FramedRead, LinesCodec};
+use std::io::Cursor;
+
+#[bench]
+fn short(b: &mut test::Bencher) {
+    let data = [
+        ["a"; 16].join("b"),
+        ["b"; 16].join("c"),
+        ["c"; 16].join("d"),
+    ].join("\n");
+    b.iter(|| {
+        executor::block_on(async {
+            let read = Cursor::new(test::black_box(&data));
+            let mut framed = FramedRead::new(read, LinesCodec {});
+
+            framed.try_next().await.unwrap();
+            framed.try_next().await.unwrap();
+            framed.try_next().await.is_ok()
+        })
+    })
+}
+
+#[bench]
+fn medium(b: &mut test::Bencher) {
+    let data = [
+        ["a"; 128].join("b"),
+        ["b"; 128].join("c"),
+        ["c"; 128].join("d"),
+    ].join("\n");
+    b.iter(|| {
+        executor::block_on(async {
+            let read = Cursor::new(test::black_box(&data));
+            let mut framed = FramedRead::new(read, LinesCodec {});
+
+            framed.try_next().await.unwrap();
+            framed.try_next().await.unwrap();
+            framed.try_next().await.is_ok()
+        })
+    })
+}
+
+#[bench]
+fn long(b: &mut test::Bencher) {
+    let data = [
+        ["a"; 2048].join("b"),
+        ["b"; 2048].join("c"),
+        ["c"; 2048].join("d"),
+    ].join("\n");
+    b.iter(|| {
+        executor::block_on(async {
+            let read = Cursor::new(test::black_box(&data));
+            let mut framed = FramedRead::new(read, LinesCodec {});
+
+            framed.try_next().await.unwrap();
+            framed.try_next().await.unwrap();
+            framed.try_next().await.is_ok()
+        })
+    })
+}

--- a/src/codec/lines.rs
+++ b/src/codec/lines.rs
@@ -1,6 +1,7 @@
 use crate::{Decoder, Encoder};
 use bytes::{BufMut, BytesMut};
 use std::io::{Error, ErrorKind};
+use memchr::memchr;
 
 /// A simple `Codec` implementation that splits up data into lines.
 pub struct LinesCodec {}
@@ -21,8 +22,8 @@ impl Decoder for LinesCodec {
     type Error = Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        match src.iter().position(|b| b == &b'\n') {
-            Some(pos) if !src.is_empty() => {
+        match memchr(b'\n', src) {
+            Some(pos) => {
                 let buf = src.split_to(pos + 1);
                 String::from_utf8(buf.to_vec())
                     .map(Some)


### PR DESCRIPTION
Benchmarking results on my MacBook Air with 1,6 GHz Intel Core i5 (one of three runs each, runs were within an eyeballed 1% of each other):

Before:

```
test long   ... bench:      10,252 ns/iter (+/- 401)
test medium ... bench:       1,742 ns/iter (+/- 78)
test short  ... bench:       1,082 ns/iter (+/- 94)
```

After:

```
test long   ... bench:       1,895 ns/iter (+/- 267)
test medium ... bench:       1,170 ns/iter (+/- 72)
test short  ... bench:         997 ns/iter (+/- 90)
```