### PR TITLE
Update to futures 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ categories = ["asynchronous", "network-programming"]
 
 [dependencies]
 bytes = "0.4.12"
-futures-preview = "0.3.0-alpha.17"
+futures = "0.3.0"
 memchr = "2.2.1"

--- a/src/codec/bytes.rs
+++ b/src/codec/bytes.rs
@@ -10,7 +10,7 @@ use std::io::Error;
 /// #![feature(async_await)]
 /// use bytes::Bytes;
 /// use futures::{SinkExt, TryStreamExt};
-/// use std::io::Cursor;
+/// use futures::io::Cursor;
 /// use futures_codec::{BytesCodec, Framed};
 ///
 /// async move {

--- a/src/framed.rs
+++ b/src/framed.rs
@@ -68,7 +68,7 @@ impl<T: AsyncWrite + Unpin, U> AsyncWrite for Fuse<T, U> {
 /// #![feature(async_await)]
 /// use bytes::Bytes;
 /// use futures::{executor, SinkExt, TryStreamExt};
-/// use std::io::Cursor;
+/// use futures::io::Cursor;
 /// use futures_codec::{BytesCodec, Framed};
 ///
 /// executor::block_on(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! ```
 //! # #![feature(async_await)]
 //! # use futures::{executor, SinkExt, TryStreamExt};
-//! # use std::io::Cursor;
+//! # use futures::io::Cursor;
 //! use futures_codec::{LinesCodec, Framed};
 //!
 //! async move {

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,12 +1,12 @@
 use futures::{executor, TryStreamExt};
 use futures_codec::{BytesCodec, Framed};
-use std::io::Cursor;
+use futures::io::Cursor;
 
 #[test]
 fn decodes() {
     let mut buf = [0u8; 32];
     let expected = buf.clone();
-    let cur = Cursor::new(&mut buf);
+    let cur = Cursor::new(&mut buf[..]);
     let mut framed = Framed::new(cur, BytesCodec {});
 
     let read = executor::block_on(framed.try_next()).unwrap().unwrap();

--- a/tests/framed_read.rs
+++ b/tests/framed_read.rs
@@ -1,10 +1,10 @@
 use futures::executor;
 use futures::stream::StreamExt;
-use futures::task::Context;
-use futures::{AsyncRead, Poll};
+use futures::AsyncRead;
 use futures_codec::{FramedRead, LinesCodec};
 use std::io;
 use std::pin::Pin;
+use std::task::{Context, Poll};
 
 // Sends two lines at once, then nothing else forever
 struct MockBurstySender {

--- a/tests/lines.rs
+++ b/tests/lines.rs
@@ -1,6 +1,6 @@
 use futures::{executor, TryStreamExt};
 use futures_codec::{FramedRead, LinesCodec};
-use std::io::Cursor;
+use futures::io::Cursor;
 
 #[test]
 fn it_works() {


### PR DESCRIPTION
One thing to be aware of is that `AsyncRead`/`AsyncWrite` are now implemented on `futures::io::Cursor` only, and no longer on `std::io::Cursor`. See https://github.com/rust-lang-nursery/futures-rs/pull/1943.