### PR TITLE
Fix len delimited codec

### DIFF
--- a/src/codec/length.rs
+++ b/src/codec/length.rs
@@ -67,8 +67,13 @@ impl Decoder for LengthCodec {
             return Ok(None);
         }
 
-        let len = src.get_u64() as usize;
+        let mut len_bytes = [0u8; U64_LENGTH];
+        len_bytes.copy_from_slice(&src[..U64_LENGTH]);
+        let len = u64::from_be_bytes(len_bytes) as usize;
+
         if src.len() - U64_LENGTH >= len {
+            // Skip the length header we already read.
+            src.advance(U64_LENGTH);
             Ok(Some(src.split_to(len).freeze()))
         } else {
             Ok(None)

--- a/src/codec/length.rs
+++ b/src/codec/length.rs
@@ -75,3 +75,23 @@ impl Decoder for LengthCodec {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod decode {
+        use super::*;
+
+        #[test]
+        fn it_returns_bytes_withouth_length_header() {
+            let mut codec = LengthCodec{ };
+
+            let mut src = BytesMut::with_capacity(5);
+            src.put(&[0, 0, 0, 0, 0, 0, 0, 3u8, 1, 2, 3, 4][..]);
+            let item = codec.decode(&mut src).unwrap();
+
+            assert!(item == Some(Bytes::from(&[1u8, 2, 3][..])));
+        }
+    }
+}

--- a/tests/length_delimited.rs
+++ b/tests/length_delimited.rs
@@ -1,0 +1,29 @@
+use bytes::Bytes;
+use futures::io::Cursor;
+use futures::{executor, SinkExt, StreamExt};
+use futures_codec::{Framed, LengthCodec};
+
+#[test]
+fn same_msgs_are_received_as_were_sent() {
+    let cur = Cursor::new(vec![0; 256]);
+    let mut framed = Framed::new(cur, LengthCodec {});
+
+    let send_msgs = async {
+        framed.send(Bytes::from("msg1")).await.unwrap();
+        framed.send(Bytes::from("msg2")).await.unwrap();
+        framed.send(Bytes::from("msg3")).await.unwrap();
+    };
+    executor::block_on(send_msgs);
+
+    let (mut cur, _) = framed.release();
+    cur.set_position(0);
+    let framed = Framed::new(cur, LengthCodec {});
+
+    let recv_msgs = framed.take(3)
+        .map(|res| res.unwrap())
+        .map(|buf| String::from_utf8(buf.to_vec()).unwrap())
+        .collect::<Vec<_>>();
+    let msgs: Vec<String> = executor::block_on(recv_msgs);
+
+    assert!(msgs == vec!["msg1", "msg2", "msg3"]);
+}


### PR DESCRIPTION
The problem was that in decode() 'src' buffer was advanced too soon.
This caused a couple of bugs at least in 2 scenarios:

1. when encoded frame was smaller than 8 bytes.
2. when 'src' did not have enough bytes to decode a complete frame.

## Problem 1

Say we encode a frame [1, 2, 3].
The resulting buffer is [0, 0, 0, 0, 0, 0, 0, 3, 1, 2, 3] - with prepended
length header.
Then decode() takes this buffer, correctly parses len as 3, and then
does this comparison:

    if src.len() - U64_LENGTH

Given that we already advanced src buffer, src.len() now is 3 (11 - 8).
This results in uderflow: 3 - 8, which panics.

## Problem 2

Say we have framed a TCP stream where data is coming in chunks but not
necessarily in the size of our frames.
Say we call decode() for the first time with src = [0, 0, 0, 0, 0, 0, 0, 64, 1, 2, 3].
Obviously this is not a full frame: it's size is 64 but only first 3 bytes have arrived.
In this case decode() used to advance the src buffer, but still return None.
So when a next TCP packet arrives, decode() was called for the second time.
decode() then used to attempt to parse len header again. And this time it
would parse the bytes [1, 2, 3, ...] as a len header which is actually
our data.