### PR TITLE
feat: Add the Decode::decode_eof method

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -12,6 +12,15 @@ pub trait Decoder {
 
     /// Decode an item from the src `BytesMut` into an item
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error>;
+
+    /// Called when the input stream reaches EOF, signaling a last attempt to decode
+    ///
+    /// # Notes
+    ///
+    /// The default implementation of this method invokes the `Decoder::decode` method.
+    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.decode(src)
+    }
 }
 
 impl<T, U: Decoder> Decoder for Fuse<T, U> {
@@ -21,6 +30,10 @@ impl<T, U: Decoder> Decoder for Fuse<T, U> {
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         self.u.decode(src)
     }
+
+    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.u.decode_eof(src)
+    }
 }
 
 impl<T: Decoder> Decoder for FramedWrite2<T> {
@@ -29,5 +42,9 @@ impl<T: Decoder> Decoder for FramedWrite2<T> {
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         self.inner.decode(src)
+    }
+
+    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.inner.decode_eof(src)
     }
 }

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -137,13 +137,16 @@ where
                     if this.buffer.is_empty() {
                         return Poll::Ready(None);
                     } else {
-                        // this is the end of the input but there are bytes left
-                        // maybe do something like tokio's `decode_eof` here instead?
-                        return Poll::Ready(Some(Err(io::Error::new(
-                            io::ErrorKind::UnexpectedEof,
-                            "bytes remaining in stream",
-                        )
-                        .into())));
+                        match this.inner.decode_eof(&mut this.buffer)? {
+                            Some(item) => return Poll::Ready(Some(Ok(item))),
+                            None => {
+                                return Poll::Ready(Some(Err(io::Error::new(
+                                    io::ErrorKind::UnexpectedEof,
+                                    "bytes remaining in stream",
+                                )
+                                .into())));
+                            }
+                        }
                     }
                 }
                 _ => continue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,10 @@
 mod codec;
 pub use codec::{BytesCodec, LengthCodec, LinesCodec};
 
-#[cfg(feature = "json")] pub use codec::{JsonCodec, JsonCodecError};
-#[cfg(feature = "cbor")] pub use codec::{CborCodec, CborCodecError};
+#[cfg(feature = "cbor")]
+pub use codec::{CborCodec, CborCodecError};
+#[cfg(feature = "json")]
+pub use codec::{JsonCodec, JsonCodecError};
 
 mod decoder;
 pub use decoder::Decoder;


### PR DESCRIPTION
Necessary for decoding messages which also rely on EOF to signal the end.

Closes #35 