### PR TITLE
Revert "Added all-features for docs.rs build"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ documentation = "https://docs.rs/crate/futures_codec"
 keywords = ["future", "futures", "async", "codec"]
 categories = ["asynchronous", "network-programming"]
 
-[package.metadata.docs.rs]
-all-features = true
-
 [features]
 default = []
 json = [ "serde", "serde_json" ]


### PR DESCRIPTION
Reverts matthunz/futures-codec#38

The flag was already set here:
https://github.com/tomaka/futures-codec/blob/0c7a69ee7f40a97f888b5ef618ab0791e58a23f5/Cargo.toml#L39-L40

The duplicate section now causes the master branch to not compile.

I would also suggest some basic CI.
