### PR TITLE
Support packed CBOR maps

### DIFF
--- a/src/codec/cbor.rs
+++ b/src/codec/cbor.rs
@@ -135,9 +135,9 @@ where
     fn encode(&mut self, data: Self::Item, buf: &mut BytesMut) -> Result<(), Self::Error> {
         // Encode cbor
         let j = if self.packed {
-            serde_cbor::to_vec_packed(&data)?
+            serde_cbor::ser::to_vec_packed(&data)?
         } else {
-            serde_cbor::ser::to_vec(&data)?
+            serde_cbor::to_vec(&data)?
         };
 
         // Write to buffer
@@ -202,7 +202,7 @@ mod test {
 
     #[test]
     fn cbor_codec_packed_encode_decode() {
-        let mut codec = CborCodec::<TestStruct, TestStruct>::new().packed_format();
+        let mut codec = CborCodec::<TestStruct, TestStruct>::new().set_packed(true);
         let mut buff = BytesMut::new();
 
         let item1 = TestStruct {

--- a/src/codec/cbor.rs
+++ b/src/codec/cbor.rs
@@ -74,15 +74,18 @@ where
         }
     }
 
-    /// Encode CBOR values in packed format.
+    /// When `true`, encode CBOR values in packed format.
     ///
-    /// In the packed format enum variant names and field names are replaced
+    /// In the packed format enum variant and struct field names are replaced
     /// with numeric indices to conserve space. This may, however, reduce
     /// portability. See [section 3.7] of the CBOR specification.
     ///
+    /// The default value is `false`, i.e. variant and field names are encoded
+    /// as UTF-8 strings.
+    ///
     /// [section 3.7]: https://tools.ietf.org/html/rfc7049#section-3.7
-    pub fn packed_format(mut self) -> Self {
-        self.packed = true;
+    pub fn set_packed(mut self, packed: bool) -> Self {
+        self.packed = packed;
         self
     }
 }

--- a/src/codec/cbor.rs
+++ b/src/codec/cbor.rs
@@ -132,9 +132,9 @@ where
     fn encode(&mut self, data: Self::Item, buf: &mut BytesMut) -> Result<(), Self::Error> {
         // Encode cbor
         let j = if self.packed {
-            serde_cbor::to_vec(&data)?
+            serde_cbor::to_vec_packed(&data)?
         } else {
-            serde_cbor::ser::to_vec_packed(&data)?
+            serde_cbor::ser::to_vec(&data)?
         };
 
         // Write to buffer


### PR DESCRIPTION
This is a proposal to add support for "packed" CBOR map keys, as supported by the underlying [serde_cbor](https://docs.rs/serde_cbor/0.11.1/serde_cbor/ser/struct.Serializer.html#method.packed_format) crate.