### PR TITLE
Reexport Bytes and BytesMut from this crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 
 mod codec;
 pub use codec::{BytesCodec, LengthCodec, LinesCodec};
+pub use bytes::{Bytes, BytesMut};
 
 #[cfg(feature = "cbor")]
 pub use codec::{CborCodec, CborCodecError};

--- a/tests/framed_read.rs
+++ b/tests/framed_read.rs
@@ -1,8 +1,7 @@
-use bytes::BytesMut;
 use futures::executor;
 use futures::stream::StreamExt;
 use futures::AsyncRead;
-use futures_codec::{Decoder, FramedRead, LinesCodec};
+use futures_codec::{Decoder, FramedRead, LinesCodec, BytesMut};
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/tests/framed_write.rs
+++ b/tests/framed_write.rs
@@ -1,9 +1,8 @@
-use bytes::Bytes;
 use core::iter::Iterator;
 use futures::io::{AsyncWrite, Cursor};
 use futures::sink::SinkExt;
 use futures::{executor, stream, stream::StreamExt};
-use futures_codec::{BytesCodec, FramedWrite, LinesCodec};
+use futures_codec::{BytesCodec, FramedWrite, LinesCodec, Bytes};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 

--- a/tests/length_delimited.rs
+++ b/tests/length_delimited.rs
@@ -1,7 +1,6 @@
-use bytes::Bytes;
 use futures::io::Cursor;
 use futures::{executor, SinkExt, StreamExt};
-use futures_codec::{Framed, LengthCodec};
+use futures_codec::{Framed, LengthCodec, Bytes};
 
 #[test]
 fn same_msgs_are_received_as_were_sent() {


### PR DESCRIPTION
These types are coming from the `bytes` crate and are used in the public API of the Encoder and Decoder traits. Re-exporting makes using this crate more pleasant because users don't have to add an explicit dependency on `bytes`.