### PR TITLE
Added some extra methods to be compatible with tokio_util::codec

### DIFF
--- a/src/framed.rs
+++ b/src/framed.rs
@@ -2,6 +2,7 @@ use super::framed_read::{framed_read_2, FramedRead2};
 use super::framed_write::{framed_write_2, FramedWrite2};
 use super::fuse::Fuse;
 use super::{Decoder, Encoder};
+use bytes::BytesMut;
 use futures::io::{AsyncRead, AsyncWrite};
 use futures::{Sink, Stream, TryStreamExt};
 use pin_project::pin_project;
@@ -72,6 +73,38 @@ where
     pub fn release(self: Self) -> (T, U) {
         let fuse = self.inner.release().release();
         (fuse.t, fuse.u)
+    }
+
+    /// Consumes the `Framed`, returning its underlying I/O stream.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn into_inner(self) -> T {
+        self.release().0
+    }
+
+    /// Returns a reference to the underlying codec wrapped by
+    /// `Framed`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying codec
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn codec(&self) -> &U {
+        &self.inner.u
+    }
+
+    /// Returns a mutable reference to the underlying codec wrapped by
+    /// `Framed`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying codec
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn codec_mut(&mut self) -> &mut U {
+        &mut self.inner.u
+    }
+
+    /// Returns a reference to the read buffer.
+    pub fn read_buffer(&self) -> &BytesMut {
+        self.inner.buffer()
     }
 }
 

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -65,6 +65,36 @@ where
         let fuse = self.inner.release();
         (fuse.t, fuse.u)
     }
+
+    /// Consumes the `FramedRead`, returning its underlying I/O stream.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn into_inner(self) -> T {
+        self.release().0
+    }
+
+    /// Returns a reference to the underlying decoder.
+    ///
+    /// Note that care should be taken to not tamper with the underlying decoder
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn decoder(&self) -> &D {
+        &self.inner.u
+    }
+
+    /// Returns a mutable reference to the underlying decoder.
+    ///
+    /// Note that care should be taken to not tamper with the underlying decoder
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn decoder_mut(&mut self) -> &mut D {
+        &mut self.inner.u
+    }
+
+    /// Returns a reference to the read buffer.
+    pub fn read_buffer(&self) -> &BytesMut {
+        &self.inner.buffer
+    }
 }
 
 impl<T, D> Stream for FramedRead<T, D>
@@ -178,5 +208,9 @@ where
 impl<T> FramedRead2<T> {
     pub fn release(self: Self) -> T {
         self.inner
+    }
+
+    pub fn buffer(&self) -> &BytesMut {
+        &self.buffer
     }
 }

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -87,6 +87,31 @@ where
         let fuse = self.inner.release();
         (fuse.t, fuse.u)
     }
+
+    /// Consumes the `FramedWrite`, returning its underlying I/O stream.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn into_inner(self) -> T {
+        self.release().0
+    }
+
+    /// Returns a reference to the underlying encoder.
+    ///
+    /// Note that care should be taken to not tamper with the underlying encoder
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn encoder(&self) -> &E {
+        &self.inner.u
+    }
+
+    /// Returns a mutable reference to the underlying encoder.
+    ///
+    /// Note that care should be taken to not tamper with the underlying encoder
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn encoder_mut(&mut self) -> &mut E {
+        &mut self.inner.u
+    }
 }
 
 impl<T, E> Sink<E::Item> for FramedWrite<T, E>


### PR DESCRIPTION
* Added methods for accessing to codec:
  - `Framed::codec`
  - `Framed::codec_mut`
  - `FramedRead::decoder`
  - `FramedRead::decoder_mut`
  - `FramedWrite::encoder`
  - `FramedWrite::encoder_mut`
* Added methods for accessing to read buffer:
  - `Framed::read_buffer`
  - `FramedRead::read_buffer`
* Added methods for releasing stream only:
  - `Framed::into_inner`
  - `FramedRead::into_inner`
  - `FramedWrite::into_inner`