### PR TITLE
End stream if `decode_eof` consumed buffer and returned `None`

### DIFF
--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -169,6 +169,7 @@ where
                     } else {
                         match this.inner.decode_eof(&mut this.buffer)? {
                             Some(item) => return Poll::Ready(Some(Ok(item))),
+                            None if this.buffer.is_empty() => return Poll::Ready(None),
                             None => {
                                 return Poll::Ready(Some(Err(io::Error::new(
                                     io::ErrorKind::UnexpectedEof,


### PR DESCRIPTION
This allows decoders to discard trailing data by doing
`src.split_to(src.len())`. Previously, I did this [in sse-codec][4237f05]
by copying incoming data in `decode()` but that's a
little less efficient.

Now, if the `decode_eof()` implementation consumed all data but still
returns `None`, we just end the stream.

[4237f05]: https://github.com/goto-bus-stop/sse-codec/commit/4237f05e4b39b6e5292cbf2011397ae46ab984c7#diff-b4aea3e418ccdb71239b96952d9cddb6