### PR TITLE
Reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,13 @@ cbor = [ "serde", "serde_cbor" ]
 
 [dependencies]
 bytes = "0.5.4"
-futures = "0.3.5"
-memchr = "2.2.3"
-pin-project = "0.4.22"
+futures-sink = "0.3.7"
+futures-util = { version = "0.3.7", features = ["io"] }
+memchr = "2.3.4"
+pin-project-lite = "0.1.11"
+
+[dev-dependencies]
+futures = "0.3.7"
 
 [dependencies.serde]
 version = '1.0.113'

--- a/benches/lines.rs
+++ b/benches/lines.rs
@@ -2,9 +2,8 @@
 
 extern crate test;
 
-use futures::{executor, TryStreamExt};
+use futures::{executor, io::Cursor, TryStreamExt};
 use futures_codec::{FramedRead, LinesCodec};
-use std::io::Cursor;
 
 #[bench]
 fn short(b: &mut test::Bencher) {

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -2,9 +2,11 @@ use super::fuse::Fuse;
 use super::Decoder;
 
 use bytes::BytesMut;
-use futures::io::AsyncRead;
-use futures::{ready, Sink, Stream, TryStreamExt};
-use pin_project::pin_project;
+use futures_sink::Sink;
+use futures_util::io::AsyncRead;
+use futures_util::ready;
+use futures_util::stream::{Stream, TryStreamExt};
+use pin_project_lite::pin_project;
 use std::io;
 use std::marker::Unpin;
 use std::ops::{Deref, DerefMut};
@@ -61,7 +63,7 @@ where
     }
 
     /// Release the I/O and Decoder
-    pub fn release(self: Self) -> (T, D) {
+    pub fn release(self) -> (T, D) {
         let fuse = self.inner.release();
         (fuse.t, fuse.u)
     }
@@ -109,12 +111,13 @@ where
     }
 }
 
-#[pin_project]
-#[derive(Debug)]
-pub struct FramedRead2<T> {
-    #[pin]
-    inner: T,
-    buffer: BytesMut,
+pin_project! {
+    #[derive(Debug)]
+    pub struct FramedRead2<T> {
+        #[pin]
+        inner: T,
+        buffer: BytesMut,
+    }
 }
 
 impl<T> Deref for FramedRead2<T> {
@@ -207,7 +210,7 @@ where
 }
 
 impl<T> FramedRead2<T> {
-    pub fn release(self: Self) -> T {
+    pub fn release(self) -> T {
         self.inner
     }
 

--- a/src/fuse.rs
+++ b/src/fuse.rs
@@ -1,17 +1,18 @@
-use futures::io::{AsyncRead, AsyncWrite};
-use pin_project::pin_project;
+use futures_util::io::{AsyncRead, AsyncWrite};
+use pin_project_lite::pin_project;
 use std::io::Error;
 use std::marker::Unpin;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-#[pin_project]
-#[derive(Debug)]
-pub(crate) struct Fuse<T, U> {
-    #[pin]
-    pub t: T,
-    pub u: U,
+pin_project! {
+    #[derive(Debug)]
+    pub(crate) struct Fuse<T, U> {
+        #[pin]
+        pub t: T,
+        pub u: U,
+    }
 }
 
 impl<T, U> Fuse<T, U> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@
 //! ```
 
 mod codec;
-pub use codec::{BytesCodec, LengthCodec, LinesCodec};
 pub use bytes::{Bytes, BytesMut};
+pub use codec::{BytesCodec, LengthCodec, LinesCodec};
 
 #[cfg(feature = "cbor")]
 pub use codec::{CborCodec, CborCodecError};

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -5,7 +5,7 @@ use futures_codec::{BytesCodec, Framed};
 #[test]
 fn decodes() {
     let mut buf = [0u8; 32];
-    let expected = buf.clone();
+    let expected = buf;
     let cur = Cursor::new(&mut buf[..]);
     let mut framed = Framed::new(cur, BytesCodec {});
 

--- a/tests/framed_read.rs
+++ b/tests/framed_read.rs
@@ -1,7 +1,7 @@
 use futures::executor;
 use futures::stream::StreamExt;
 use futures::AsyncRead;
-use futures_codec::{Decoder, FramedRead, LinesCodec, BytesMut};
+use futures_codec::{BytesMut, Decoder, FramedRead, LinesCodec};
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -16,7 +16,7 @@ impl AsyncRead for MockBurstySender {
         _cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        const MESSAGES: &'static [u8] = b"one\ntwo\n";
+        const MESSAGES: &[u8] = b"one\ntwo\n";
         if !self.sent && buf.len() >= MESSAGES.len() {
             self.sent = true;
             buf[0..MESSAGES.len()].clone_from_slice(MESSAGES);

--- a/tests/framed_write.rs
+++ b/tests/framed_write.rs
@@ -2,7 +2,7 @@ use core::iter::Iterator;
 use futures::io::{AsyncWrite, Cursor};
 use futures::sink::SinkExt;
 use futures::{executor, stream, stream::StreamExt};
-use futures_codec::{BytesCodec, FramedWrite, LinesCodec, Bytes};
+use futures_codec::{Bytes, BytesCodec, FramedWrite, LinesCodec};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 

--- a/tests/length_delimited.rs
+++ b/tests/length_delimited.rs
@@ -1,6 +1,6 @@
 use futures::io::Cursor;
 use futures::{executor, SinkExt, StreamExt};
-use futures_codec::{Framed, LengthCodec, Bytes};
+use futures_codec::{Bytes, Framed, LengthCodec};
 
 #[test]
 fn same_msgs_are_received_as_were_sent() {


### PR DESCRIPTION
This replaces the large `futures` crate with its lighter weight dependencies `futures-util` and `futures-sink`, and uses `pin-project-lite` instead of `pin-project` for better compilation times.