### PR TITLE
Update bytes to 0.6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures_codec"
 edition = "2018"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Matt Hunzinger <matthunz2@gmail.com>"]
 description = "Utilities for encoding and decoding frames using `async/await`"
 license = "MIT"
@@ -18,8 +18,8 @@ json = [ "serde", "serde_json" ]
 cbor = [ "serde", "serde_cbor" ]
 
 [dependencies]
-bytes = "0.5.4"
-futures = "0.3.5"
+bytes = "0.6"
+futures = "0.3"
 memchr = "2.2.3"
 pin-project = "0.4.22"
 


### PR DESCRIPTION
This allows dependent crates to use the latest version of bytes.