### PR TITLE
Permit conversion into and creation from "parts".

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,12 @@ mod encoder;
 pub use encoder::Encoder;
 
 mod framed;
-pub use framed::Framed;
+pub use framed::{Framed, FramedParts};
 
 mod framed_read;
-pub use framed_read::FramedRead;
+pub use framed_read::{FramedRead, FramedReadParts};
 
 mod framed_write;
-pub use framed_write::FramedWrite;
+pub use framed_write::{FramedWrite, FramedWriteParts};
 
 mod fuse;

--- a/tests/framed_write.rs
+++ b/tests/framed_write.rs
@@ -57,7 +57,7 @@ fn line_write() {
     let mut framer = FramedWrite::new(curs, LinesCodec {});
     executor::block_on(framer.send("Hello\n".to_owned())).unwrap();
     executor::block_on(framer.send("World\n".to_owned())).unwrap();
-    let (curs, _) = framer.release();
+    let curs = framer.into_inner();
     assert_eq!(&curs.get_ref()[0..12], b"Hello\nWorld\n");
     assert_eq!(curs.position(), 12);
 }
@@ -69,7 +69,7 @@ fn line_write_to_eof() {
     let mut framer = FramedWrite::new(curs, LinesCodec {});
     let _err =
         executor::block_on(framer.send("This will fill up the buffer\n".to_owned())).unwrap_err();
-    let (curs, _) = framer.release();
+    let curs = framer.into_inner();
     assert_eq!(curs.position(), 16);
     assert_eq!(&curs.get_ref()[0..16], b"This will fill u");
 }
@@ -93,7 +93,7 @@ fn send_high_water_mark() {
     let mut framer = FramedWrite::new(io, BytesCodec {});
     framer.set_send_high_water_mark(500);
     executor::block_on(framer.send_all(&mut stream)).unwrap();
-    let (io, _) = framer.release();
+    let io = framer.into_inner();
     assert_eq!(io.num_poll_write, 2);
     assert_eq!(io.last_write_size, 499);
 }

--- a/tests/length_delimited.rs
+++ b/tests/length_delimited.rs
@@ -14,7 +14,7 @@ fn same_msgs_are_received_as_were_sent() {
     };
     executor::block_on(send_msgs);
 
-    let (mut cur, _) = framed.release();
+    let mut cur = framed.into_inner();
     cur.set_position(0);
     let framed = Framed::new(cur, LengthCodec {});
 


### PR DESCRIPTION
This PR generalises `Framed::release()` et al to `Framed::into_parts()`, providing corresponding `Framed::from_parts`. This is pretty much analogous to `tokio_util::codec::FramedParts`. There are mainly two use-cases:

   1. Resuing framed buffers with a new codec (https://github.com/tokio-rs/tokio/issues/717).
   2. Protocols that use a particular `Framed` only e.g. during a handshake phase after which they want to drop down to direct use of the underlying I/O stream. Since the `Framed` may have read and buffered data beyond the handshake frames, it is necessary to drain the remaining read buffer first when doing this. While one can already obtain the read buffer from `Framed::read_buffer()`, using it to capture the buffer before calling `Framed::into_inner()` requires to unnecessarily clone the `BytesMut`.

I also tweaked the documentation a bit to make it clearer that the `into_inner()` methods may discard buffered data. Since this PR removes / renames `Framed::release()` et al to `into_parts`, the API changes are not backward-compatible.