### PR TITLE
Mark feature-gated items in docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,12 @@ rust:
   - stable
   - beta
   - nightly
+
+jobs:
+  include:
+    - rust: nightly
+      env:
+        RUSTDOCFLAGS: --cfg=docsrs --deny=broken_intra_doc_links
+      # Skip default `cargo build`
+      install: true
+      script: cargo doc --all-features --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,4 @@ optional = true
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/codec/cbor.rs
+++ b/src/codec/cbor.rs
@@ -33,6 +33,7 @@ use serde_cbor::Error as CborError;
 /// };
 /// ```
 #[derive(Debug, PartialEq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "cbor")))]
 pub struct CborCodec<Enc, Dec> {
     enc: PhantomData<Enc>,
     dec: PhantomData<Dec>,
@@ -40,6 +41,7 @@ pub struct CborCodec<Enc, Dec> {
 
 /// JSON Codec error enumeration
 #[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "cbor")))]
 pub enum CborCodecError {
     /// IO error
     Io(IoError),

--- a/src/codec/json.rs
+++ b/src/codec/json.rs
@@ -31,6 +31,7 @@ use serde::{Deserialize, Serialize};
 /// };
 /// ```
 #[derive(Debug, PartialEq)]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub struct JsonCodec<Enc, Dec> {
     enc: PhantomData<Enc>,
     dec: PhantomData<Dec>,
@@ -38,6 +39,7 @@ pub struct JsonCodec<Enc, Dec> {
 
 /// JSON Codec error enumeration
 #[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub enum JsonCodecError {
     /// IO error
     Io(std::io::Error),
@@ -153,7 +155,6 @@ where
     }
 }
 
-
 impl<Enc, Dec> Default for JsonCodec<Enc, Dec>
 where
     for<'de> Dec: Deserialize<'de> + 'static,
@@ -163,7 +164,6 @@ where
         Self::new()
     }
 }
-
 
 #[cfg(test)]
 mod test {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
 //! Utilities for encoding and decoding frames using `async/await`.
 //!
-//! Contains adapters to go from streams of bytes, [`AsyncRead`](futures::io::AsyncRead)
-//! and [`AsyncWrite`](futures::io::AsyncWrite), to framed streams implementing [`Sink`](futures::Sink) and [`Stream`](futures::Stream).
-//! Framed streams are also known as `transports`.
+//! Contains adapters to go from streams of bytes, [`AsyncRead`](futures-util::io::AsyncRead) and
+//! [`AsyncWrite`](futures-util::io::AsyncWrite), to framed streams implementing
+//! [`Sink`](futures-util::Sink) and [`Stream`](futures-util::Stream). Framed streams are also
+//! known as `transports`.
 //!
 //! ```
 //! # futures::executor::block_on(async move {
@@ -26,8 +28,10 @@ pub use bytes::{Bytes, BytesMut};
 pub use codec::{BytesCodec, LengthCodec, LinesCodec};
 
 #[cfg(feature = "cbor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub use codec::{CborCodec, CborCodecError};
 #[cfg(feature = "json")]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub use codec::{JsonCodec, JsonCodecError};
 
 mod decoder;


### PR DESCRIPTION
We’re making use of the [`doc(cfg(..))`][1] attribute to mark items in the docs that are behind feature flags. The approach seems pretty standard and is, for example, followed by the `futures-*` and `async_std` crates.

To ensure this is tested we add an additional travis job for this. This also checks the [`broken_intra_doc_links`][2] lint. To pass, we fixed the links in the crate documentation in `lib.rs`.

[1]: https://doc.rust-lang.org/rustdoc/unstable-features.html#documenting-platform-feature-specific-information
[2]: https://doc.rust-lang.org/rustdoc/lints.html#broken_intra_doc_links